### PR TITLE
correct "auth_url" to "jwt_auth_url"

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Discourse Plugin to enable authentication via JSON Web Tokens (JWT)
 Add the following settings to your `discourse.conf` file:
 
 - `jwt_secret`
-- `auth_url`
+- `jwt_auth_url`
 
 ### License
 


### PR DESCRIPTION
plugin.rb has the following line where it references `jwt_auth_url`:
```
:auth_url => GlobalSetting.jwt_auth_url
```