### PR TITLE
DEV: Add support for omniauth-2

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -4,7 +4,7 @@
 # version: 0.1
 # author: Robin Ward
 
-gem "discourse-omniauth-jwt", "0.0.2", require: false
+gem "omniauth-jwt2", "0.1.0", require: false
 
 require "omniauth/jwt"
 


### PR DESCRIPTION
The original omniauth-jwt gem is unmaintained, so we made discourse-omniauth-jwt. Now, the original has been forked again, with upgrades and fixes incorporated from Aha, Discourse and GitLab. This one has Omniauth 2.0 support, so it makes sense to use that rather than upgrading our own fork.