### PR TITLE
DEV: Vendor the JWT OmniAuth strategy

### DIFF
--- a/lib/omniauth/strategies/jwt.rb
+++ b/lib/omniauth/strategies/jwt.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "jwt"
+
+module OmniAuth
+  module Strategies
+    class JWT
+      class ClaimInvalid < StandardError
+      end
+
+      include OmniAuth::Strategy
+
+      option :secret, nil
+      option :auth_url, nil
+      option :algorithm, "HS256"
+      option :uid_claim, "email"
+      option :required_claims, %w[name email]
+      option :info_map, { name: "name", email: "email" }
+
+      def request_phase
+        redirect(options.auth_url)
+      end
+
+      def callback_phase
+        super
+      rescue ::JWT::DecodeError => e
+        fail!(:bad_jwt, e)
+      rescue ClaimInvalid => e
+        fail!(:claim_invalid, e)
+      end
+
+      def decoded
+        @decoded ||=
+          begin
+            claims =
+              ::JWT.decode(
+                request.params["jwt"],
+                options.secret,
+                true,
+                algorithms: [options.algorithm],
+              ).first
+
+            Array(options.required_claims).each do |claim|
+              raise ClaimInvalid, "Missing required '#{claim}' claim." if !claims.key?(claim.to_s)
+            end
+
+            claims
+          end
+      end
+
+      uid { decoded[options.uid_claim] }
+
+      info { options.info_map.to_h { |key, claim| [key.to_s, decoded[claim.to_s]] } }
+
+      extra { { raw_info: decoded } }
+    end
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -4,9 +4,7 @@
 # version: 0.1
 # author: Robin Ward
 
-gem "omniauth-jwt2", "0.1.0", require: false
-
-require "omniauth/jwt"
+require_relative "lib/omniauth/strategies/jwt"
 
 class JWTAuthenticator < Auth::ManagedAuthenticator
   def name
@@ -14,7 +12,7 @@ class JWTAuthenticator < Auth::ManagedAuthenticator
   end
 
   def register_middleware(omniauth)
-    omniauth.provider :jwt,
+    omniauth.provider OmniAuth::Strategies::JWT,
                       name: "jwt",
                       uid_claim: "id",
                       required_claims: %w[id email name],

--- a/spec/requests/jwt_auth_spec.rb
+++ b/spec/requests/jwt_auth_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+RSpec.describe "JWT authentication" do
+  let(:secret) { "a-shared-secret" }
+  let(:claims) { { "id" => "user-42", "email" => "jwt@example.com", "name" => "JWT User" } }
+
+  def token_for(payload, key: secret)
+    JWT.encode(payload, key, "HS256")
+  end
+
+  before do
+    enable_current_plugin
+    SiteSetting.jwt_enabled = true
+    SiteSetting.jwt_secret = secret
+    SiteSetting.jwt_auth_url = "https://sso.example.com/login"
+  end
+
+  it "sends the user to the configured auth URL" do
+    post "/auth/jwt"
+
+    expect(response.status).to eq(302)
+    expect(response.location).to eq("https://sso.example.com/login")
+  end
+
+  it "accepts a token signed with the site secret" do
+    post "/auth/jwt/callback", params: { jwt: token_for(claims) }
+
+    expect(response.status).to eq(302)
+    expect(response.location).to eq("http://test.localhost/")
+
+    data = JSON.parse(cookies[:authentication_data])
+    expect(data["auth_provider"]).to eq("jwt")
+    expect(data["email"]).to eq("jwt@example.com")
+    expect(data["name"]).to eq("JWT User")
+  end
+
+  it "rejects a token signed with another secret" do
+    post "/auth/jwt/callback", params: { jwt: token_for(claims, key: "wrong") }
+
+    expect(response.location).to eq("/auth/failure?message=bad_jwt&strategy=jwt")
+  end
+
+  it "rejects an expired token" do
+    post "/auth/jwt/callback", params: { jwt: token_for(claims.merge("exp" => 1.hour.ago.to_i)) }
+
+    expect(response.location).to eq("/auth/failure?message=bad_jwt&strategy=jwt")
+  end
+
+  it "rejects a token that is missing a required claim" do
+    post "/auth/jwt/callback", params: { jwt: token_for(claims.except("email")) }
+
+    expect(response.location).to eq("/auth/failure?message=claim_invalid&strategy=jwt")
+  end
+
+  it "rejects an unsigned token" do
+    unsigned = JWT.encode(claims, nil, "none")
+
+    post "/auth/jwt/callback", params: { jwt: unsigned }
+
+    expect(response.location).to eq("/auth/failure?message=bad_jwt&strategy=jwt")
+  end
+end


### PR DESCRIPTION
The plugin installed `omniauth-jwt2` from plugin.rb, and every release of that gem pins `jwt` below 3, so core cannot move to jwt 3 (https://github.com/discourse/discourse/pull/43295) while any site has this plugin. The strategy is very simple, so we can bring it into the plugin and use the `jwt` gem core already ships.

- Only the HS256 shared-secret path is kept, since that is all the plugin configures. A bad signature, an expired token or an unsigned token fails with `bad_jwt`; a missing claim fails with `claim_invalid`, as before.

- Register the strategy by class so it no longer depends on OmniAuth's name camelization.

- Add request specs for the redirect, a valid token and each rejection.